### PR TITLE
bugfix (08-18-24)

### DIFF
--- a/src/main/java/com/prix/homepage/user/controller/SearchLogUserController.java
+++ b/src/main/java/com/prix/homepage/user/controller/SearchLogUserController.java
@@ -37,6 +37,9 @@ public class SearchLogUserController {
         for(SearchLogUser searchLog : searchLogDto){
             Integer id = searchLog.getUserId();
             String userName = searchLogService.findName(id);
+            if(id == 4){
+                userName = "anonymous";
+            }
             userNames.put(id, userName);
         }
         Map<Integer, String> msFiles = new HashMap<>();

--- a/src/main/resources/templates/admin/searchlog.html
+++ b/src/main/resources/templates/admin/searchlog.html
@@ -48,7 +48,7 @@
 
     <tbody th:if="${searchLogDto != null}">
         <tr th:each="searchLog, stat : ${searchLogDto}">
-            <td class="grayTD"><div align="center"><a th:href="@{/livesearch/result(file=${searchLog.result})}" target="_blank" th:text="${stat.index + 1}"><a/></div></td>
+            <td class="grayTD"><div align="center"><a th:href="@{${'/' + searchLog.engine + '/result'}(file=${searchLog.result})}" target="_blank" th:text="${stat.index + 1}"><a/></div></td>
                 <td class="grayTD"><div align="center" th:text="${userNames[searchLog.userId]}"></div></td>
                 <td class="grayTD"><div align="center" th:text="${searchLog.date}"></div></td>
                 <td class="grayTD"><div align="center" th:text="${searchLog.title}"></div></td>

--- a/src/main/resources/templates/livesearch/history.html
+++ b/src/main/resources/templates/livesearch/history.html
@@ -56,7 +56,7 @@
             <td class="grayTH"><div align="center">Engine</div></td>
         </tr>
         <tr th:each="searchLog, stat : ${searchLogUsersDto}">
-            <td class="grayTD"><div align="center"><a th:href="@{/livesearch/result(file=${searchLog.result})}" th:text="${stat.index + 1}" ><a/></div></td>
+            <td class="grayTD"><div align="center"><a th:href="@{${'/' + searchLog.engine + '/result'}(file=${searchLog.result})}" th:text="${stat.index + 1}" ><a/></div></td>
             <td class="grayTD"><div align="center" th:text="${searchLog.date}"></div></td>
             <td class="grayTD"><div align="center" th:text="${searchLog.title}"></div></td>
             <td class="grayTD"><div align="center" th:text="${msFiles[searchLog.msfile]}"></div></td>

--- a/src/main/resources/templates/livesearch/historyModi.html
+++ b/src/main/resources/templates/livesearch/historyModi.html
@@ -45,7 +45,7 @@
       </tr>
 
       <tr th:each="searchLog, stat : ${searchLogUsersDto}">
-        <td class="grayTD"><div align="center"><a href="/livesearch/result" th:text="${stat.index + 1}"><a/></div></td>
+        <td class="grayTD"><div align="center"><a th:href="@{${'/' + searchLog.engine + '/result'}(file=${searchLog.result})}" th:text="${stat.index + 1}"><a/></div></td>
         <td class="grayTD"><div align="center" th:text="${searchLog.date}"></div></td>
         <td class="grayTD"><div align="center" th:text="${searchLog.title}"></div></td>
         <td class="grayTD"><div align="center" th:text="${msFiles[searchLog.msfile]}"></div></td>


### PR DESCRIPTION
!!History page work

1. fixed a bug where SearchLog was incorrectly displaying userId == 4 as null instead of "anonymous".
2. fixed a bug where searchlog index did not connect to the corresponding result page.
3. fixed a bug where history and historyModi did not connect to the corresponding result page.

Unresolved Issue: Modplus jobQueue list is being displayed on the history page. However, Modplus has been removed from livesearch, leaving no result page to connect it to.