### PR TITLE
Pattern match pagination

### DIFF
--- a/src/main/java/com/prix/homepage/livesearch/controller/PatternMatchController.java
+++ b/src/main/java/com/prix/homepage/livesearch/controller/PatternMatchController.java
@@ -1,5 +1,7 @@
 package com.prix.homepage.livesearch.controller;
 
+import java.io.PrintWriter;
+
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 
@@ -10,6 +12,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import com.prix.homepage.livesearch.patternMatch.PatternMatch;
 import com.prix.homepage.livesearch.pojo.PatternMatchDto;
 import com.prix.homepage.livesearch.service.PatternMatchService;
+
+import jakarta.servlet.http.HttpServletResponse;
 
 @Controller
 @AllArgsConstructor
@@ -52,45 +56,59 @@ public class PatternMatchController {
     @PostMapping("/patternMatch/patternMatchResult")
     public String getPatternMatchResult(Model model, PatternMatchDto patternMatchDto) {
 
-        String db_t = patternMatchDto.getDb_type().equals("0") ? "swiss_prot" : "genbank";
-        String sd = "";
-        sd = patternMatchService.getUpdateDay(db_t);
-
-        String[] pattern = { patternMatchDto.getPattern1(),
-                patternMatchDto.getPattern2(),
-                patternMatchDto.getPattern3(), patternMatchDto.getPattern4(),
-                patternMatchDto.getPattern5() };
-        pattern = java.util.Arrays.stream(pattern).filter(p -> p != null &&
-                !p.equals("")).toArray(String[]::new);
-
-        String format_type = patternMatchDto.getFormat_type().equals("0") ? "PROSITE"
-                : "PYTHON";
-        boolean check_order = patternMatchDto.getCheck_order() != null;
-        boolean check_except = patternMatchDto.getCheck_except() != null;
-        boolean check_species = patternMatchDto.getCheck_species() != null;
-        String species = patternMatchDto.getSpecies();
-
-        PatternMatch p = new PatternMatch(format_type, db_t, pattern, check_species,
-                species, check_except, check_order);
-        p.DBParameter("prix", "Prix2024!@", "166.104.110.37/");
-        // System.out.println("Form type: " + format_type + ", db_type: " + db_t);
-
-        StringBuilder result = new StringBuilder();
         try {
+            String db_t = patternMatchDto.getDb_type().equals("0") ? "swiss_prot" : "genbank";
+            String sd = "";
+            sd = patternMatchService.getUpdateDay(db_t);
+            // out.print("<li>" + db_t + " Release : (" + sd + ")</li><br>");
+            // out.flush(); // 클라이언트에게 즉시 전송
+
+            String[] pattern = { patternMatchDto.getPattern1(),
+                    patternMatchDto.getPattern2(),
+                    patternMatchDto.getPattern3(), patternMatchDto.getPattern4(),
+                    patternMatchDto.getPattern5() };
+            pattern = java.util.Arrays.stream(pattern).filter(p -> p != null &&
+                    !p.equals("")).toArray(String[]::new);
+
+            String format_type = patternMatchDto.getFormat_type().equals("0") ? "PROSITE"
+                    : "PYTHON";
+            boolean check_order = patternMatchDto.getCheck_order() != null;
+            boolean check_except = patternMatchDto.getCheck_except() != null;
+            boolean check_species = patternMatchDto.getCheck_species() != null;
+            String species = patternMatchDto.getSpecies();
+
+            PatternMatch p = new PatternMatch(format_type, db_t, pattern, check_species,
+                    species, check_except, check_order);
+            p.DBParameter("prix", "Prix2024!@", "166.104.110.37/");
+            // System.out.println("Form type: " + format_type + ", db_type: " + db_t);
+
+            StringBuilder result = new StringBuilder();
             p.MainMethod();
-            String oneResult = p.getOneProtein();
+            // String oneResult = p.getOneProtein();
+            String oneResult = "";
+            // p.MainMethod();
             while (oneResult != null) {
-                result.append(oneResult).append("<br>");
+                result.append(oneResult);
+                // out.print(oneResult + "<br>"); // 결과를 화면에 출력
                 oneResult = p.getOneProtein();
+                // out.flush(); // 클라이언트에게 바로 전송
             }
             result.append(p.getParameter());
+            // out.println(p.getParameter() + "<br>");
+
+            model.addAttribute("dbType", db_t);
+            model.addAttribute("date", sd);
+            model.addAttribute("result", result.toString());
 
         } catch (Exception e) {
+            // try (PrintWriter out = response.getWriter()) {
+            // out.println("Error");
+            // out.println("" + e.getStackTrace()[0]);
+            // e.printStackTrace(out);
+            // } catch (Exception ex) {
             e.printStackTrace();
+            // }
         }
-        model.addAttribute("dbType", db_t);
-        model.addAttribute("date", sd);
-        model.addAttribute("result", result.toString());
 
         return "livesearch/patternMatchResult";
     }

--- a/src/main/java/com/prix/homepage/livesearch/controller/PatternMatchController.java
+++ b/src/main/java/com/prix/homepage/livesearch/controller/PatternMatchController.java
@@ -1,6 +1,7 @@
 package com.prix.homepage.livesearch.controller;
 
-import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -12,8 +13,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import com.prix.homepage.livesearch.patternMatch.PatternMatch;
 import com.prix.homepage.livesearch.pojo.PatternMatchDto;
 import com.prix.homepage.livesearch.service.PatternMatchService;
-
-import jakarta.servlet.http.HttpServletResponse;
 
 @Controller
 @AllArgsConstructor
@@ -60,8 +59,6 @@ public class PatternMatchController {
             String db_t = patternMatchDto.getDb_type().equals("0") ? "swiss_prot" : "genbank";
             String sd = "";
             sd = patternMatchService.getUpdateDay(db_t);
-            // out.print("<li>" + db_t + " Release : (" + sd + ")</li><br>");
-            // out.flush(); // 클라이언트에게 즉시 전송
 
             String[] pattern = { patternMatchDto.getPattern1(),
                     patternMatchDto.getPattern2(),
@@ -80,35 +77,33 @@ public class PatternMatchController {
             PatternMatch p = new PatternMatch(format_type, db_t, pattern, check_species,
                     species, check_except, check_order);
             p.DBParameter("prix", "Prix2024!@", "166.104.110.37/");
-            // System.out.println("Form type: " + format_type + ", db_type: " + db_t);
-
-            StringBuilder result = new StringBuilder();
             p.MainMethod();
-            // String oneResult = p.getOneProtein();
+
+            List<String> allResults = new ArrayList<String>();
             String oneResult = "";
-            // p.MainMethod();
             while (oneResult != null) {
-                result.append(oneResult);
-                // out.print(oneResult + "<br>"); // 결과를 화면에 출력
-                oneResult = p.getOneProtein();
-                // out.flush(); // 클라이언트에게 바로 전송
+                allResults.add(oneResult);
+                oneResult = p.getOneProtein(); // 검색된 결과를 하나씩 가져온다
             }
-            result.append(p.getParameter());
-            // out.println(p.getParameter() + "<br>");
+
+            allResults.add(p.getParameter()); // 마지막에 찾은 protein과 pattern의 수를 화면에 출력
 
             model.addAttribute("dbType", db_t);
             model.addAttribute("date", sd);
-            model.addAttribute("result", result.toString());
+            model.addAttribute("allResults", allResults); // 조건에 맞는 데이터set을 넘겨줌
 
         } catch (Exception e) {
-            // try (PrintWriter out = response.getWriter()) {
-            // out.println("Error");
-            // out.println("" + e.getStackTrace()[0]);
-            // e.printStackTrace(out);
-            // } catch (Exception ex) {
             e.printStackTrace();
-            // }
         }
+        // 08.18 메모
+        // db에서 데이터를 실시간으로 받아오는 것이 아니었다.. 데이터가 클수록 가져오는데 시간이 오래걸림.
+        // 실시간으로 받아오는 것처럼 보이는 건 랜더링 로딩이었다!
+        // controller에서 out.print가 아닌 result.html 페이지에서 데이터를 랜더링하면 데이터가 큰 경우 터지는 버그ㅜ
+        // 페이지 네이션은 실패
+        // html 파일을 랜더링 하지 않고 파비콘과 탭 title을 설정하는 방법 구상해보기 끼야아아악
+        // 08.19 메모
+        // 한 번 가져온 result를 활용하자! db에서 받아온 데이터를 모두 클라이언트에게 넘긴다.
+        // -> 클라이언트에서 페이지네이션 진행. 넘겨받은 result 중 일부만 랜더링하는 방식.
 
         return "livesearch/patternMatchResult";
     }

--- a/src/main/java/com/prix/homepage/livesearch/patternMatch/MySQL.java
+++ b/src/main/java/com/prix/homepage/livesearch/patternMatch/MySQL.java
@@ -21,7 +21,8 @@ public class MySQL {
         this.db = var4;
 
         try {
-            Class.forName("org.gjt.mm.mysql.Driver").newInstance();
+            // Class.forName("org.gjt.mm.mysql.Driver").newInstance();
+            Class.forName("com.mysql.cj.jdbc.Driver");
         } catch (Exception var6) {
             var6.printStackTrace();
         }

--- a/src/main/resources/templates/livesearch/patternMatchResult.html
+++ b/src/main/resources/templates/livesearch/patternMatchResult.html
@@ -8,27 +8,118 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pattern Match Result</title>
     <link rel="icon" th:href="@{/images/ci.gif}" type="image/gif" />
+
+    <style>
+      .pagination {
+        display: flex;
+        justify-content: center;
+        margin-top: 20px;
+        flex-wrap: wrap;
+      }
+      .pagination button,
+      .pagination span {
+        margin: 0 3px;
+        padding: 5px 10px;
+        border: 1px solid #ccc;
+        background-color: #f1f1f1;
+        cursor: pointer;
+      }
+      .pagination button.active {
+        background-color: #007bff;
+        color: white;
+      }
+      .pagination button:disabled {
+        background-color: #ccc;
+        cursor: not-allowed;
+      }
+      .pagination span {
+        cursor: default;
+      }
+    </style>
   </head>
 
   <body>
     <li th:text=" ${dbType} +' Release : (' + ${date} + ')'"></li>
-    <div style="margin: 15px" th:utext="${result}"></div>
+    <div id="results"></div>
 
-    <br />
+    <div class="pagination" id="pagination"></div>
 
-    <!--
-      <script>
-        const source = new EventSource("/patternMatch/patternMatchResult");
-        
-        source.onmessage = function (event) {
-          document.getElementById("result").innerHTML += event.data;
-        };
-        
-        source.onerror = function () {
-          console.error("An error occurred while receiving updates.");
-          source.close();
-        };
-      </script>
-      -->
+    <script type="text/javascript" th:inline="javascript">
+      const allResults = /*[[${allResults}]]*/ [];
+
+      const pageSize = 500; // 한 페이지에 표시할 항목 수
+      let currentPage = 1;
+
+      function renderPage(page) {
+        const start = (page - 1) * pageSize;
+        const end = start + pageSize;
+        const pageResult = allResults.slice(start, end);
+
+        const resultsContainer = document.getElementById("results");
+        resultsContainer.innerHTML = "";
+        pageResult.forEach((result) => {
+          // HTML 콘텐츠를 innerHTML로 삽입
+          resultsContainer.innerHTML += result;
+        });
+
+        renderPagination();
+
+        if (currentPage != 1)
+          window.scrollTo({
+            top: document.body.scrollHeight,
+          });
+      }
+
+      function renderPagination() {
+        const totalPages = Math.ceil(allResults.length / pageSize);
+        const paginationContainer = document.getElementById("pagination");
+        paginationContainer.innerHTML = "";
+
+        const pagination = document.createElement("div");
+        pagination.className = "pagination";
+
+        // Previous button
+        const prevButton = document.createElement("button");
+        prevButton.textContent = "Previous";
+        prevButton.disabled = currentPage === 1;
+        prevButton.addEventListener("click", () => {
+          if (currentPage > 1) {
+            currentPage--;
+            renderPage(currentPage);
+          }
+        });
+        pagination.appendChild(prevButton);
+
+        // Page buttons
+        const startPage = Math.max(1, currentPage - 5);
+        const endPage = Math.min(totalPages, currentPage + 5);
+
+        for (let i = startPage; i <= endPage; i++) {
+          const pageButton = document.createElement("button");
+          pageButton.textContent = i;
+          pageButton.className = i === currentPage ? "active" : "";
+          pageButton.addEventListener("click", () => {
+            currentPage = i;
+            renderPage(currentPage);
+          });
+          pagination.appendChild(pageButton);
+        }
+
+        // Next button
+        const nextButton = document.createElement("button");
+        nextButton.textContent = "Next";
+        nextButton.disabled = currentPage === totalPages;
+        nextButton.addEventListener("click", () => {
+          if (currentPage < totalPages) {
+            currentPage++;
+            renderPage(currentPage);
+          }
+        });
+        pagination.appendChild(nextButton);
+
+        paginationContainer.appendChild(pagination);
+      }
+      renderPage(currentPage);
+    </script>
   </body>
 </html>

--- a/src/main/resources/templates/livesearch/patternMatchResult.html
+++ b/src/main/resources/templates/livesearch/patternMatchResult.html
@@ -1,14 +1,34 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
   <head>
-    <title>PatternMatch Result</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=euc-kr" />
+    <meta charset="UTF-8" />
+    <meta property="og:title" content="attern Match Result" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="images/ci.gif" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pattern Match Result</title>
+    <link rel="icon" th:href="@{/images/ci.gif}" type="image/gif" />
   </head>
 
   <body>
-    <div style="margin: 15px">
-      <li th:text="${dbType} + ' Release : ' + ' (' + ${date} + ')'"></li>
-      <div th:utext="${result}"></div>
-    </div>
+    <li th:text=" ${dbType} +' Release : (' + ${date} + ')'"></li>
+    <div style="margin: 15px" th:utext="${result}"></div>
+
+    <br />
+
+    <!--
+      <script>
+        const source = new EventSource("/patternMatch/patternMatchResult");
+        
+        source.onmessage = function (event) {
+          document.getElementById("result").innerHTML += event.data;
+        };
+        
+        source.onerror = function () {
+          console.error("An error occurred while receiving updates.");
+          source.close();
+        };
+      </script>
+      -->
   </body>
 </html>


### PR DESCRIPTION
pattern match 결과값을 patternMatchResult.html 페이지에 랜더링.
기존 out.print 방식과 다르게 클라이언트측에 결과값을 보낸 후 랜더링.
결과 데이터셋의 크기가 큰 경우 랜더링 시간 초과로 터지는 버그 발생.
-> 페이지네이션으로 해결
